### PR TITLE
feat(config): expose more options through global config

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ It is an abstraction over Popper that provides the logic and optionally the styl
 
 This is a lightweight wrapper with additional features that lets you use it declaratively in Angular. Tippy has virtually no restrictions over Popper and gives you limitless control while providing useful behavior and defaults.
 
+<a href="https://www.buymeacoffee.com/basalnetanel" target="_blank"><img src="https://www.buymeacoffee.com/assets/img/custom_images/orange_img.png" alt="Buy Me A Coffee" style="height: 41px !important;width: 174px !important;box-shadow: 0px 3px 2px 0px rgba(190, 190, 190, 0.5) !important;-webkit-box-shadow: 0px 3px 2px 0px rgba(190, 190, 190, 0.5) !important;" ></a>
+
 ## Features
 
 ✅ Tooltip & Popover Variations <br>
@@ -188,6 +190,8 @@ export class AppModule {}
 ```
 
 - `closeIcon` - The svg close icon that'll be used inside the popper.
+- `helipopperClass` - String or array of string of custom classes that'll be added to the tooltip.
+- `allowHtml` - Whether or not to globally allow HTML or not. Default is true.
 
 ## Contributors ✨
 

--- a/projects/ngneat/helipopper/src/lib/helipopper.directive.spec.ts
+++ b/projects/ngneat/helipopper/src/lib/helipopper.directive.spec.ts
@@ -1,0 +1,56 @@
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HelipopperModule } from './helipopper.module';
+import { By } from '@angular/platform-browser';
+import { HelipopperDirective } from './helipopper.directive';
+
+@Component({
+  template: `
+    <button class="tester" id="first-button" helipopper="Helpful Message">
+      I have a tooltip
+    </button>
+
+    <button id="second-button" helipopper="Helpful Message" helipopperClass="inline-class">
+      I have a tooltip
+    </button>
+  `
+})
+class TestHelipopperComponent {}
+
+describe('Helipopper directive', () => {
+  let component: TestHelipopperComponent;
+  let fixture: ComponentFixture<TestHelipopperComponent>;
+
+  beforeEach(() => {
+    fixture = TestBed.configureTestingModule({
+      declarations: [TestHelipopperComponent, HelipopperDirective],
+      imports: [HelipopperModule.forRoot({ allowHtml: true, helipopperClass: 'global-class' })]
+    }).createComponent(TestHelipopperComponent);
+    fixture.detectChanges();
+    component = fixture.componentInstance;
+  });
+
+  it('adds global classes', () => {
+    fixture.whenStable().then(() => {
+      let button = fixture.debugElement.query(By.css('#first-button'));
+      button.triggerEventHandler('mouseenter', null);
+
+      fixture.detectChanges();
+
+      let tooltip = fixture.debugElement.query(By.css('#tippy-1'));
+      expect(Object.keys(tooltip.classes)).toEqual(['global-class']);
+    });
+  });
+
+  it('appends inline classes to global classes', () => {
+    fixture.whenStable().then(() => {
+      let button = fixture.debugElement.query(By.css('#second-button'));
+      button.triggerEventHandler('mouseenter', null);
+
+      fixture.detectChanges();
+
+      let tooltip = fixture.debugElement.query(By.css('#tippy-2'));
+      expect(Object.keys(tooltip.classes)).toEqual(['global-class', 'inline-class']);
+    });
+  });
+});

--- a/projects/ngneat/helipopper/src/lib/helipopper.directive.ts
+++ b/projects/ngneat/helipopper/src/lib/helipopper.directive.ts
@@ -190,19 +190,22 @@ export class HelipopperDirective implements OnDestroy {
     }
 
     this.helipopperTrigger = this.resolveTrigger();
-
     this.instance = tippy(this._tooltipHost, {
       content: undefined,
       appendTo: this.getParent(),
       arrow: !this.isTooltip,
-      allowHTML: true,
+      allowHTML: this.config.allowHtml || this.mergedConfig.allowHtml,
       zIndex: 1000000,
       trigger: this.helipopperTrigger,
       placement: this._placement,
       triggerTarget: this._tooltipTarget,
       // TODO: Merge the following methods with the passed config
       onCreate: instance => {
-        this.helipopperClass && addClass(instance.popper, this.helipopperClass);
+        let classes = []
+          .concat(this.mergedConfig.helipopperClass)
+          .concat(this.helipopperClass)
+          .filter(v => !!v);
+        addClass(instance.popper, classes);
       },
       onShow: instance => {
         this.zone.run(() => this.instance.setContent(this.resolveContent()));
@@ -309,7 +312,9 @@ export class HelipopperDirective implements OnDestroy {
       closeIcon: icon,
       beforeRender(content: string): string {
         return content;
-      }
+      },
+      helipopperClass: [],
+      allowHtml: true
     };
 
     return {

--- a/projects/ngneat/helipopper/src/lib/helipopper.types.ts
+++ b/projects/ngneat/helipopper/src/lib/helipopper.types.ts
@@ -9,6 +9,8 @@ export type Element = HTMLElement | ElementRef | undefined;
 export type HelipopperConfig = {
   beforeRender?(content: string): string;
   closeIcon?: string;
+  helipopperClass?: string | Array<string>;
+  allowHtml?: boolean;
 };
 
 export const HELIPOPPER_CONFIG = new InjectionToken<HelipopperConfig>('HELIPOPPER_CONFIG');


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Current behavior allows for 2 global options:
- closeIcon
- beforeRender

Issue Number: 1

## What is the new behavior?
Global options now also support:
- allowHtml
- helipopperClass

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information
I struggled a lot with the unit test here since there was none to begin with. It still is not working correctly. I also wasn't really sure what options you wanted to expose globally, so I picked a couple that I thought might make sense.