### PR TITLE
feat: add @output() method to expose current tooltip status as boolean

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,22 @@ Now you can use it:
 </button>
 ```
 
+#### Handle current status as boolean
+
+```html
+<button helipopper="Helpful Message" (helipopperShowing)="handleStatus($event)">
+  Click Me
+</button>
+```
+
+and on .ts
+
+```ts
+handleStatus($event: boolean): void {
+  console.log('show tooltip', $event);
+}
+```
+
 #### Text Overflow:
 
 ```html
@@ -237,6 +253,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Now you can use it:
 #### Handle current status as boolean
 
 ```html
-<button helipopper="Helpful Message" (helipopperShowing)="handleStatus($event)">
+<button helipopper="Helpful Message" (helipopperVisible)="handleStatus($event)">
   Click Me
 </button>
 ```
@@ -186,6 +186,13 @@ You have the freedom to [customize](https://atomiks.github.io/tippyjs/v6/themes/
 | helipopperSticky       | `Boolean`                 | Whether the tooltip should be sticky (i.e. always displayed) | `false`                                                                |
 | helipopperTarget       | `ElementRef` \| `Element` | The element(s) that the trigger event listeners are added to | `Host`                                                                 |  | Ex: `{ width: '100%', height: '70px' }` |
 | helipopperInjector     | `Injector` \| `undefined` | The custom injector to be provided                           | `none`                                                                 |
+
+## Outputs
+
+| @Output           | Type               | Description                                               |
+| ----------------- | ------------------ | --------------------------------------------------------- |
+| helipopperClose   | `Subject<any>`     | Method called when tooltip is closed                      |
+| helipopperVisible | `Subject<boolean>` | Method that emits the tooltip's current status as boolean |
 
 ## Config
 

--- a/projects/ngneat/helipopper/src/lib/helipopper.directive.ts
+++ b/projects/ngneat/helipopper/src/lib/helipopper.directive.ts
@@ -118,6 +118,8 @@ export class HelipopperDirective implements OnDestroy {
   }
 
   @Output() helipopperClose = new Subject();
+  @Output() helipopperShowing = new Subject<boolean>();
+  // @Output() helipopperShowing = new EventEmitter<boolean>();
 
   private _content: Content;
   private _destroy = new Subject();
@@ -217,11 +219,13 @@ export class HelipopperDirective implements OnDestroy {
       onShow: instance => {
         this.zone.run(() => this.instance.setContent(this.resolveContent()));
         this.helipopperAllowClose && this.isPopper && this.addCloseButton(instance as InstanceWithClose);
+        this.helipopperShowing.next(true);
       },
       onHidden: instance => {
         this.helipopperAllowClose && this.isPopper && this.removeCloseButton(instance as InstanceWithClose);
         this.destroyView();
         this.helipopperClose.next();
+        this.helipopperShowing.next(false);
       },
       ...this.resolveTheme(),
       ...this.helipopperOptions

--- a/projects/ngneat/helipopper/src/lib/helipopper.directive.ts
+++ b/projects/ngneat/helipopper/src/lib/helipopper.directive.ts
@@ -118,8 +118,7 @@ export class HelipopperDirective implements OnDestroy {
   }
 
   @Output() helipopperClose = new Subject();
-  @Output() helipopperShowing = new Subject<boolean>();
-  // @Output() helipopperShowing = new EventEmitter<boolean>();
+  @Output() helipopperVisible = new Subject<boolean>();
 
   private _content: Content;
   private _destroy = new Subject();
@@ -219,13 +218,13 @@ export class HelipopperDirective implements OnDestroy {
       onShow: instance => {
         this.zone.run(() => this.instance.setContent(this.resolveContent()));
         this.helipopperAllowClose && this.isPopper && this.addCloseButton(instance as InstanceWithClose);
-        this.helipopperShowing.next(true);
+        this.helipopperVisible.next(true);
       },
       onHidden: instance => {
         this.helipopperAllowClose && this.isPopper && this.removeCloseButton(instance as InstanceWithClose);
         this.destroyView();
         this.helipopperClose.next();
-        this.helipopperShowing.next(false);
+        this.helipopperVisible.next(false);
       },
       ...this.resolveTheme(),
       ...this.helipopperOptions

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -174,7 +174,14 @@
 
 <div class="block">
   <h2>Custom Component</h2>
-  <button [helipopper]="comp" helipopperVariation="popper" (helipopperClose)="close()">Open component</button>
+  <button
+    [helipopper]="comp"
+    helipopperVariation="popper"
+    (helipopperClose)="close()"
+    (helipopperShowing)="handleStatus($event)"
+  >
+    Open component
+  </button>
 </div>
 
 <div class="block">

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -178,7 +178,7 @@
     [helipopper]="comp"
     helipopperVariation="popper"
     (helipopperClose)="close()"
-    (helipopperShowing)="handleStatus($event)"
+    (helipopperVisible)="handleStatus($event)"
   >
     Open component
   </button>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -112,4 +112,8 @@ export class AppComponent implements AfterViewInit {
       this.popperWithComp = this.service.open(this.inputNameComp, this.comp);
     }
   }
+
+  handleStatus($event: boolean): void {
+    console.log('show tooltip', $event);
+  }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
It introduces a very basic feature to emit as `@Output()` if the tooltip is opened or not. I added `(handleShowing)="handleStatus($event)"` in the custom component block of playground and it works.

Issue Number: #11

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
