### PR TITLE
fix: support server-side rendering

### DIFF
--- a/projects/ngneat/helipopper/src/lib/helipopper-options.ts
+++ b/projects/ngneat/helipopper/src/lib/helipopper-options.ts
@@ -1,17 +1,27 @@
+import { inject, InjectionToken, Injector } from '@angular/core';
+import { DOCUMENT } from '@angular/common';
+import { Options as PopperOptions } from '@popperjs/core';
 import { Props } from 'tippy.js';
 import { Variation } from './helipopper.types';
-import { Options as PopperOptions } from '@popperjs/core';
-import { Injector } from '@angular/core';
 
-export const initialHelipopperOptions: Partial<HelipopperOptions> = {
-  options: {},
-  textOverflow: false,
-  appendTo: document.body,
-  placement: 'top',
-  variation: 'tooltip',
-  disabled: false,
-  allowClose: true
-};
+export const INITIAL_HELIPOPPER_OPTIONS = new InjectionToken<Partial<HelipopperOptions>>('InitialHelipopperOptions', {
+  providedIn: 'root',
+  factory: () => {
+    const document = inject(DOCUMENT);
+    // The code actually shouldn't be executed on the server-side,
+    // but these options are "statically" initialized, thus Universal
+    // will throw an error "document is not defined".
+    return {
+      options: {},
+      textOverflow: false,
+      appendTo: document.body,
+      placement: 'top',
+      variation: 'tooltip',
+      disabled: false,
+      allowClose: true
+    };
+  }
+});
 
 export interface HelipopperOptions {
   options: Partial<Props>;
@@ -28,3 +38,10 @@ export interface HelipopperOptions {
   sticky: boolean;
   allowClose: boolean;
 }
+
+// This type exists because it is acceptable to the AOT compiler.
+// The AOT compiler throws:
+// `Could not resolve type Partial`
+// This happens if we use the `Partial` type in constructor, for instance:
+// `@Inject(OPTIONS) options: Partial<Options>`
+export type PartialHelipopperOptions = Partial<HelipopperOptions>;

--- a/projects/ngneat/helipopper/src/lib/helipopper.service.ts
+++ b/projects/ngneat/helipopper/src/lib/helipopper.service.ts
@@ -6,12 +6,13 @@ import {
   Injectable,
   Injector,
   NgZone,
+  PLATFORM_ID,
   TemplateRef,
   Type
 } from '@angular/core';
 import { HELIPOPPER_CONFIG, HelipopperConfig } from './helipopper.types';
 import { HelipopperDirective } from './helipopper.directive';
-import { HelipopperOptions, initialHelipopperOptions as initialOptions } from './helipopper-options';
+import { INITIAL_HELIPOPPER_OPTIONS, PartialHelipopperOptions } from './helipopper-options';
 
 @Injectable({
   providedIn: 'root'
@@ -22,36 +23,42 @@ export class HelipopperService {
     private zone: NgZone,
     private resolver: ComponentFactoryResolver,
     private hostInjector: Injector,
-    @Inject(HELIPOPPER_CONFIG) private config: HelipopperConfig
+    @Inject(PLATFORM_ID) private platformId: string,
+    @Inject(HELIPOPPER_CONFIG) private config: HelipopperConfig,
+    @Inject(INITIAL_HELIPOPPER_OPTIONS) private initialOptions: PartialHelipopperOptions
   ) {}
 
-  open(host: ElementRef, helipopper: string | TemplateRef<any> | Type<any>, options?: Partial<HelipopperOptions>) {
+  open(host: ElementRef, helipopper: string | TemplateRef<any> | Type<any>, options?: PartialHelipopperOptions) {
     let directive: HelipopperDirective = new HelipopperDirective(
       host,
       this.appRef,
       this.zone,
       this.resolver,
       this.hostInjector,
-      this.config
+      this.platformId,
+      this.config,
+      this.initialOptions
     );
 
     directive.helipopper = helipopper;
 
-    directive.helipopperOptions = options?.options || initialOptions.options;
+    directive.helipopperOptions = options?.options || this.initialOptions.options;
     directive.showOnlyOnTextOverflow = isDefined(options?.textOverflow)
       ? options?.textOverflow
-      : initialOptions.textOverflow;
+      : this.initialOptions.textOverflow;
     directive.triggerTarget = options?.triggerTarget;
-    directive.helipopperAppendTo = options?.appendTo || initialOptions.appendTo;
+    directive.helipopperAppendTo = options?.appendTo || this.initialOptions.appendTo;
     directive.helipopperTrigger = options?.trigger;
     directive.helipopperClass = options?.class;
     directive.helipopperOffset = options?.offset;
     directive.injector = options?.injector;
-    directive.placement = options?.placement || initialOptions.placement;
-    directive.variation = options?.variation || initialOptions.variation;
-    directive.disabled = isDefined(options?.disabled) ? options?.disabled : initialOptions.disabled;
+    directive.placement = options?.placement || this.initialOptions.placement;
+    directive.variation = options?.variation || this.initialOptions.variation;
+    directive.disabled = isDefined(options?.disabled) ? options?.disabled : this.initialOptions.disabled;
     directive.sticky = options?.sticky;
-    directive.helipopperAllowClose = isDefined(options?.allowClose) ? options?.allowClose : initialOptions.allowClose;
+    directive.helipopperAllowClose = isDefined(options?.allowClose)
+      ? options?.allowClose
+      : this.initialOptions.allowClose;
 
     directive.whenStable.subscribe(() => directive.show());
 


### PR DESCRIPTION
Closes #13 

Previously it was throwing many errors like `window|document|requestAnimationFrame is not defined`.

`tippy` function (which is a default export of `tippy.js`) should be called only in the browser.

After these changes:
* the Node.js server can be started w/o errors:
![image](https://user-images.githubusercontent.com/7337691/99194663-7e6ce280-2789-11eb-9083-83ae473c2d06.png)
* the HTML is returned successfully:
![image](https://user-images.githubusercontent.com/7337691/99194682-9c3a4780-2789-11eb-937f-d350e8fd337d.png)

`HelipopperDirective` just acts like no-op on the server side.