### PR TITLE
feat: add hideOnEscapeButton to close popper

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ isEnabled: boolean;
 className: string;
 onlyTextOverflow: boolean;
 useHostWidth: boolean;
+hideOnEscape: boolean;
 data: any;
 ```
 

--- a/cypress/integration/helipopper.spec.ts
+++ b/cypress/integration/helipopper.spec.ts
@@ -1,72 +1,100 @@
-Cypress.on("scrolled", element => {
+Cypress.on('scrolled', element => {
   // When we do `cy.get()` the Cypress finds the element
   // and scrolls down, thus this element becomes at the very top
   // of the page.
   // `tippy.js` will not show tooltips if they appeared in an invisible
   // part of the window.
   element.get(0).scrollIntoView({
-    block: "center",
-    inline: "center"
+    block: 'center',
+    inline: 'center'
   });
 });
 
-describe("@ngneat/helipopper", () => {
+describe('@ngneat/helipopper', () => {
+  const playground = '#tippy-playground';
+  const popperSelector = '.tippy-box .tippy-content';
+
   beforeEach(() => {
-    cy.visit("/").wait(200);
+    cy.visit('/').wait(200);
   });
 
-  describe("Manual trigger", () => {
-    it("should manually create tooltip", () => {
-      cy.get("#manual-trigger button")
+  describe('Manual trigger', () => {
+    it('should manually create tooltip', () => {
+      cy.get('#manual-trigger button')
         .first()
         .click({ force: true })
-        .get("body")
-        .contains("Helpful Message")
-        .should("exist");
+        .get('body')
+        .contains('Helpful Message')
+        .should('exist');
     });
   });
 
-  describe("Custom template", () => {
-    it("should create tooltip with a custom template", () => {
-      cy.get("#custom-template button")
+  describe('Custom template', () => {
+    it('should create tooltip with a custom template', () => {
+      cy.get('#custom-template button')
         .click({ force: true })
-        .get(".positions")
-        .contains("top")
-        .should("exist");
+        .get('.positions')
+        .contains('top')
+        .should('exist');
     });
   });
 
-  describe("Custom component", () => {
-    it("should create a tooltip with custom component", () => {
-      cy.get("#custom-component button")
+  describe('Custom component', () => {
+    it('should create a tooltip with custom component', () => {
+      cy.get('#custom-component button')
         .click({ force: true })
-        .get("app-example")
-        .contains("example works")
-        .should("exist");
+        .get('app-example')
+        .contains('example works')
+        .should('exist');
     });
   });
 
-  describe("Tippy nil values", () => {
-    it("should create a tooltip with a non-nil value", () => {
-      cy.get("#tippy-value-non-nil button")
+  describe('Tippy nil values', () => {
+    it('should create a tooltip with a non-nil value', () => {
+      cy.get('#tippy-value-non-nil button')
         .click({ force: true })
-        .get(".tippy-box .tippy-content")
-        .contains("I have a tooltip value different from nil")
-        .should("exist");
+        .get(popperSelector)
+        .contains('I have a tooltip value different from nil')
+        .should('exist');
     });
 
-    it("should not create a tooltip when using a null value", () => {
-      cy.get("#tippy-value-null button")
+    it('should not create a tooltip when using a null value', () => {
+      cy.get('#tippy-value-null button')
         .click({ force: true })
-        .get(".tippy-box .tippy-content")
-        .should("not.exist");
+        .get(popperSelector)
+        .should('not.exist');
     });
 
-    it("should not create a tooltip when using an undefined value", () => {
-      cy.get("#tippy-value-undefined button")
+    it('should not create a tooltip when using an undefined value', () => {
+      cy.get('#tippy-value-undefined button')
         .click({ force: true })
-        .get(".tippy-box .tippy-content")
-        .should("not.exist");
+        .get(popperSelector)
+        .should('not.exist');
+    });
+  });
+
+  describe('hideOnEscape', () => {
+    const tippyTriggerSelector = `${playground} .btn-container button`;
+    const tippyCheckboxSelector = '#hideOnEsc-toggle';
+
+    it('should NOT hide on Escape if hideOnEscape is false', () => {
+      cy.get(tippyCheckboxSelector)
+        .uncheck()
+        .should('not.be.checked')
+        .get(tippyTriggerSelector)
+        .click({ force: true })
+        .get(popperSelector)
+        .should('exist');
+    });
+
+    it('should hide on Escape if hideOnEscape is true', () => {
+      cy.get(tippyCheckboxSelector)
+        .check()
+        .should('be.checked')
+        .get(tippyTriggerSelector)
+        .click({ force: true })
+        .get(popperSelector)
+        .should('not.exist');
     });
   });
 });

--- a/projects/ngneat/helipopper/src/lib/utils.ts
+++ b/projects/ngneat/helipopper/src/lib/utils.ts
@@ -100,7 +100,8 @@ export function onlyTippyProps(allProps: any) {
     'className',
     'onlyTextOverflow',
     'data',
-    'content'
+    'content',
+    'hideOnEscape'
   ];
 
   Object.keys(allProps).forEach(prop => {

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,7 +1,7 @@
 <!--<button (click)="show = !show">Toggle All</button>-->
 
 <ng-container *ngIf="show">
-  <div [formGroup]="tooltipSettings" style="text-transform: capitalize">
+  <div id="tippy-playground" [formGroup]="tooltipSettings" style="text-transform: capitalize">
     <div *ngFor="let option of tooltipTypes" class="flex items-center">
       <input type="radio" formControlName="type" name="type" [value]="option" class="mr-4" />
       {{ option }}
@@ -21,12 +21,20 @@
       }}
     </div>
 
+    <hr />
+
+    <label>
+      <input type="checkbox" formControlName="hideOnEsc" id="hideOnEsc-toggle" class="mr-4" /> Hide on press escape
+      button
+    </label>
+
     <div class="btn-container">
       <button
         class="btn btn-outline-primary"
         tippy="Helpful Message"
         [placement]="tooltipPosition"
         [variation]="tooltipType"
+        [hideOnEscape]="hideOnEsc"
       >
         I have a tooltip
       </button>
@@ -142,7 +150,7 @@
       <button [isEnabled]="!isDisabled" tippy="Tooltip" class="btn btn-outline-dark">Element</button>
     </div>
 
-    <button (click)="toggle()" class="btn btn-outline-primary btn-sm">{{ isDisabled ? "Enable" : "Disable" }}</button>
+    <button (click)="toggle()" class="btn btn-outline-primary btn-sm">{{ isDisabled ? 'Enable' : 'Disable' }}</button>
   </div>
 
   <hr />

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,32 +1,33 @@
-import { Component, ElementRef, ViewChild } from "@angular/core";
-import { FormBuilder } from "@angular/forms";
-import { ExampleComponent } from "./example/example.component";
-import { interval } from "rxjs";
-import { finalize } from "rxjs/operators";
-import { TippyInstance, TippyService } from "@ngneat/helipopper";
+import { Component, ElementRef, ViewChild } from '@angular/core';
+import { FormBuilder } from '@angular/forms';
+import { ExampleComponent } from './example/example.component';
+import { interval } from 'rxjs';
+import { finalize } from 'rxjs/operators';
+import { TippyInstance, TippyService } from '@ngneat/helipopper';
 
 @Component({
-  selector: "app-root",
-  templateUrl: "./app.component.html",
-  styleUrls: ["./app.component.scss"]
+  selector: 'app-root',
+  templateUrl: './app.component.html',
+  styleUrls: ['./app.component.scss']
 })
 export class AppComponent {
-  tooltipPositions = ["auto", "top", "right", "bottom", "left"];
+  tooltipPositions = ['auto', 'top', 'right', 'bottom', 'left'];
   tooltipAlignments = [
-    { label: "start", value: "-start" },
-    { label: "center", value: "" },
-    { label: "end", value: "-end" }
+    { label: 'start', value: '-start' },
+    { label: 'center', value: '' },
+    { label: 'end', value: '-end' }
   ];
 
-  tooltipTypes = ["popper", "tooltip", "popperBorder"];
+  tooltipTypes = ['popper', 'tooltip', 'popperBorder'];
 
   tooltipSettings = this.fb.group({
-    type: this.fb.control("tooltip"),
-    alignment: this.fb.control(""),
-    position: this.fb.control("top")
+    type: this.fb.control('tooltip'),
+    alignment: this.fb.control(''),
+    position: this.fb.control('top'),
+    hideOnEsc: this.fb.control(false)
   });
 
-  interval$ = interval(1000).pipe(finalize(() => console.log("interval completed")));
+  interval$ = interval(1000).pipe(finalize(() => console.log('interval completed')));
 
   get tooltipPosition(): string {
     const { position, alignment } = this.tooltipSettings.value;
@@ -36,6 +37,10 @@ export class AppComponent {
 
   get tooltipType(): string {
     return this.tooltipSettings.value.type;
+  }
+
+  get hideOnEsc(): boolean {
+    return this.tooltipSettings.value.hideOnEsc;
   }
 
   items = Array.from({ length: 500 }, (_, i) => ({
@@ -48,7 +53,7 @@ export class AppComponent {
     label: `Value ${i + 1}`
   }));
 
-  thoughts = "We just need someone to talk to 🥺";
+  thoughts = 'We just need someone to talk to 🥺';
   isDisabled = false;
   text = `Long Long All Text`;
   comp = ExampleComponent;
@@ -59,8 +64,8 @@ export class AppComponent {
 
   constructor(private fb: FormBuilder, private service: TippyService) {}
 
-  @ViewChild("inputName", { static: true }) inputName: ElementRef;
-  @ViewChild("inputNameComp", { static: true }) inputNameComp: ElementRef;
+  @ViewChild('inputName', { static: true }) inputName: ElementRef;
+  @ViewChild('inputNameComp', { static: true }) inputNameComp: ElementRef;
   maxWidth = 300;
   show = true;
 
@@ -69,14 +74,14 @@ export class AppComponent {
   }
 
   handleStatus($event: boolean): void {
-    console.log("show tooltip", $event);
+    console.log('show tooltip', $event);
   }
 
   instance2: TippyInstance;
 
   useService(host: HTMLButtonElement) {
     if (!this.instance2) {
-      this.instance2 = this.service.create(host, "Created");
+      this.instance2 = this.service.create(host, 'Created');
     }
   }
 
@@ -85,16 +90,16 @@ export class AppComponent {
   useServiceComponent(host2: HTMLButtonElement) {
     if (!this.instance) {
       this.instance = this.service.create(host2, ExampleComponent, {
-        variation: "popper"
+        variation: 'popper'
       });
     }
   }
 
   duplicate(item: any) {
-    console.log("duplicate", item);
+    console.log('duplicate', item);
   }
 
   copy(item: any) {
-    console.log("copy", item);
+    console.log('copy', item);
   }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[x] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Issue Number: https://github.com/ngneat/helipopper/issues/42

## What is the new behavior?

If you provide `[hideOnEscapeButton]="true"` then you can close the popper on press the escape button. 

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
