### PR TITLE
fix: updating tp content from empty to value doesn't create the tp instance

### DIFF
--- a/cypress/e2e/helipopper.cy.ts
+++ b/cypress/e2e/helipopper.cy.ts
@@ -83,6 +83,79 @@ describe('@ngneat/helipopper', () => {
     });
   });
 
+  describe('Tippy dynamic nil values', () => {
+    const dynamicNilPopperSelector = `.dynamic-empty ${popperSelector}`;
+
+    it('should create a tooltip when content is set from null to value and destroy on the other hand', () => {
+      cy.get('#tippy-dynamic-nil button')
+        .trigger('mouseenter')
+        .get(dynamicNilPopperSelector)
+        .should('not.exist');
+
+      cy.get('#tippy-dynamic-nil-toggle button').click({ force: true });
+
+      cy.get('#tippy-dynamic-nil button')
+        .trigger('mouseenter')
+        .get(dynamicNilPopperSelector)
+        .contains("I'm updated NIL tooltip")
+        .should('exist')
+        .click({ force: true });
+
+      cy.get('#tippy-dynamic-nil-toggle button').click({ force: true });
+
+      cy.get('#tippy-dynamic-nil button')
+        .trigger('mouseenter')
+        .get(dynamicNilPopperSelector)
+        .should('not.exist');
+    });
+
+    it('should create a tooltip when content is set from undefined to value and destroy on the other hand', () => {
+      cy.get('#tippy-dynamic-undefined button')
+        .trigger('mouseenter')
+        .get(dynamicNilPopperSelector)
+        .should('not.exist');
+
+      cy.get('#tippy-dynamic-nil-toggle button').click({ force: true });
+
+      cy.get('#tippy-dynamic-undefined button')
+        .trigger('mouseenter')
+        .get(dynamicNilPopperSelector)
+        .contains("I'm updated undefined tooltip")
+        .should('exist')
+        .click({ force: true });
+
+      cy.get('#tippy-dynamic-nil-toggle button').click({ force: true });
+
+      cy.get('#tippy-dynamic-undefined button')
+        .trigger('mouseenter')
+        .get(dynamicNilPopperSelector)
+        .should('not.exist');
+    });
+
+    it('should create a tooltip when content is set from empty to value and destroy on the other hand', () => {
+      cy.get('#tippy-dynamic-empty button')
+        .trigger('mouseenter')
+        .get(dynamicNilPopperSelector)
+        .should('not.exist');
+
+      cy.get('#tippy-dynamic-nil-toggle button').click({ force: true });
+
+      cy.get('#tippy-dynamic-empty button')
+        .trigger('mouseenter')
+        .get(dynamicNilPopperSelector)
+        .contains("I'm updated empty string tooltip")
+        .should('exist')
+        .click({ force: true });
+
+      cy.get('#tippy-dynamic-nil-toggle button').click({ force: true });
+
+      cy.get('#tippy-dynamic-empty button')
+        .trigger('mouseenter')
+        .get(dynamicNilPopperSelector)
+        .should('not.exist');
+    });
+  });
+
   describe('hideOnEscape', () => {
     const tippyTriggerSelector = `${playground} .btn-container button`;
     const tippyCheckboxSelector = '#hideOnEsc-toggle';

--- a/projects/ngneat/helipopper/src/lib/tippy.directive.ts
+++ b/projects/ngneat/helipopper/src/lib/tippy.directive.ts
@@ -136,6 +136,14 @@ export class TippyDirective implements OnChanges, AfterViewInit, OnDestroy, OnIn
     }
 
     this.setProps({ ...this.props, ...props });
+
+    if (isChanged<NgChanges<TippyDirective>>('content', changes)) {
+      if (!changes.content.previousValue && changes.content.currentValue) {
+        this.createInstance();
+      } else if (changes.content.previousValue && !changes.content.currentValue) {
+        this.destroyInstance();
+      }
+    }
   }
 
   ngOnInit() {
@@ -298,6 +306,11 @@ export class TippyDirective implements OnChanges, AfterViewInit, OnDestroy, OnIn
 
       this.variation === 'contextMenu' && this.handleContextMenu();
     });
+  }
+
+  protected destroyInstance() {
+    this.instance?.destroy();
+    this.instance = null;
   }
 
   protected resolveContent(instance: TippyInstance) {

--- a/projects/ngneat/helipopper/src/lib/tippy.directive.ts
+++ b/projects/ngneat/helipopper/src/lib/tippy.directive.ts
@@ -78,7 +78,6 @@ export class TippyDirective implements OnChanges, AfterViewInit, OnDestroy, OnIn
   protected enabled = true;
   protected variationDefined = false;
   protected viewOptions$: ViewOptions;
-  protected checkContentChanges: boolean;
 
   /**
    * We had use `visible` event emitter previously as a `takeUntil` subscriber in multiple places
@@ -138,12 +137,11 @@ export class TippyDirective implements OnChanges, AfterViewInit, OnDestroy, OnIn
 
     this.setProps({ ...this.props, ...props });
 
-    if (this.checkContentChanges && isChanged<NgChanges<TippyDirective>>('content', changes)) {
+    if (isChanged<NgChanges<TippyDirective>>('content', changes) && !changes.content.isFirstChange()) {
       if (!changes.content.previousValue && changes.content.currentValue) {
-        this.createInstance();
+        this.initInstanceCreation();
       } else if (changes.content.previousValue && !changes.content.currentValue) {
         this.destroyInstance();
-        this.destroyView();
       }
     }
   }
@@ -157,40 +155,11 @@ export class TippyDirective implements OnChanges, AfterViewInit, OnDestroy, OnIn
   ngAfterViewInit() {
     if (isPlatformServer(this.platformId)) return;
 
-    this.zone.runOutsideAngular(() => {
-      if (this.isLazy) {
-        if (this.onlyTextOverflow) {
-          inView(this.host)
-            .pipe(
-              switchMap(() => overflowChanges(this.host)),
-              takeUntil(this.destroyed)
-            )
-            .subscribe(isElementOverflow => {
-              this.checkOverflow(isElementOverflow);
-            });
-        } else {
-          inView(this.host)
-            .pipe(takeUntil(this.destroyed))
-            .subscribe(() => {
-              this.createInstance();
-            });
-        }
-      } else if (this.onlyTextOverflow) {
-        overflowChanges(this.host)
-          .pipe(takeUntil(this.destroyed))
-          .subscribe(isElementOverflow => {
-            this.checkOverflow(isElementOverflow);
-          });
-      } else {
-        this.createInstance();
-      }
-    });
+    this.initInstanceCreation();
   }
 
   ngOnDestroy() {
-    this.destroyed.next();
     this.destroyInstance();
-    this.destroyView();
   }
 
   destroyView() {
@@ -232,9 +201,38 @@ export class TippyDirective implements OnChanges, AfterViewInit, OnDestroy, OnIn
     return this.host.getBoundingClientRect().width;
   }
 
-  protected createInstance() {
-    this.checkContentChanges = true;
+  protected initInstanceCreation() {
+    this.zone.runOutsideAngular(() => {
+      if (this.isLazy) {
+        if (this.onlyTextOverflow) {
+          inView(this.host)
+            .pipe(
+              switchMap(() => overflowChanges(this.host)),
+              takeUntil(this.destroyed)
+            )
+            .subscribe(isElementOverflow => {
+              this.checkOverflow(isElementOverflow);
+            });
+        } else {
+          inView(this.host)
+            .pipe(takeUntil(this.destroyed))
+            .subscribe(() => {
+              this.createInstance();
+            });
+        }
+      } else if (this.onlyTextOverflow) {
+        overflowChanges(this.host)
+          .pipe(takeUntil(this.destroyed))
+          .subscribe(isElementOverflow => {
+            this.checkOverflow(isElementOverflow);
+          });
+      } else {
+        this.createInstance();
+      }
+    });
+  }
 
+  protected createInstance() {
     if (!this.content && !coerceBooleanInput(this.useTextContent)) {
       return;
     }
@@ -313,7 +311,9 @@ export class TippyDirective implements OnChanges, AfterViewInit, OnDestroy, OnIn
   }
 
   protected destroyInstance() {
+    this.destroyed.next();
     this.instance?.destroy();
+    this.destroyView();
     this.instance = null;
   }
 

--- a/projects/ngneat/helipopper/src/lib/tippy.directive.ts
+++ b/projects/ngneat/helipopper/src/lib/tippy.directive.ts
@@ -143,6 +143,7 @@ export class TippyDirective implements OnChanges, AfterViewInit, OnDestroy, OnIn
         this.createInstance();
       } else if (changes.content.previousValue && !changes.content.currentValue) {
         this.destroyInstance();
+        this.destroyView();
       }
     }
   }
@@ -188,7 +189,7 @@ export class TippyDirective implements OnChanges, AfterViewInit, OnDestroy, OnIn
 
   ngOnDestroy() {
     this.destroyed.next();
-    this.instance?.destroy();
+    this.destroyInstance();
     this.destroyView();
   }
 

--- a/projects/ngneat/helipopper/src/lib/tippy.directive.ts
+++ b/projects/ngneat/helipopper/src/lib/tippy.directive.ts
@@ -78,6 +78,7 @@ export class TippyDirective implements OnChanges, AfterViewInit, OnDestroy, OnIn
   protected enabled = true;
   protected variationDefined = false;
   protected viewOptions$: ViewOptions;
+  protected checkContentChanges: boolean;
 
   /**
    * We had use `visible` event emitter previously as a `takeUntil` subscriber in multiple places
@@ -137,7 +138,7 @@ export class TippyDirective implements OnChanges, AfterViewInit, OnDestroy, OnIn
 
     this.setProps({ ...this.props, ...props });
 
-    if (isChanged<NgChanges<TippyDirective>>('content', changes)) {
+    if (this.checkContentChanges && isChanged<NgChanges<TippyDirective>>('content', changes)) {
       if (!changes.content.previousValue && changes.content.currentValue) {
         this.createInstance();
       } else if (changes.content.previousValue && !changes.content.currentValue) {
@@ -231,6 +232,8 @@ export class TippyDirective implements OnChanges, AfterViewInit, OnDestroy, OnIn
   }
 
   protected createInstance() {
+    this.checkContentChanges = true;
+
     if (!this.content && !coerceBooleanInput(this.useTextContent)) {
       return;
     }

--- a/src/app/playground/playground.component.html
+++ b/src/app/playground/playground.component.html
@@ -78,25 +78,25 @@
   <div>
     <h6>Dynamic NIL values</h6>
 
-    <div class="btn-container">
-      <button [tp]="nilTooltip" class="btn btn-outline-secondary">
+    <div class="btn-container" id="tippy-dynamic-nil">
+      <button [tp]="nilTooltip" tpClassName="dynamic-empty" class="btn btn-outline-secondary">
         I'm tooltip initialized to NIL. Click "Set tooltips" to see me.
       </button>
     </div>
 
-    <div class="btn-container">
-      <button [tp]="undefinedTooltip" class="btn btn-outline-secondary">
+    <div class="btn-container" id="tippy-dynamic-undefined">
+      <button [tp]="undefinedTooltip" tpClassName="dynamic-empty" class="btn btn-outline-secondary">
         I'm tooltip initialized to undefined. Click "Set tooltips" to see me.
       </button>
     </div>
 
-    <div class="btn-container">
-      <button [tp]="emptyTooltip" class="btn btn-outline-secondary">
+    <div class="btn-container" id="tippy-dynamic-empty">
+      <button [tp]="emptyTooltip" tpClassName="dynamic-empty" class="btn btn-outline-secondary">
         I'm tooltip initialized to empty string. Click "Set tooltips" to see me.
       </button>
     </div>
 
-    <div class="btn-container">
+    <div class="btn-container" id="tippy-dynamic-nil-toggle">
       <button class="btn btn-outline-secondary" (click)="updateEmptyTooltips()">
         {{ nilTooltip ? 'Unset tooltips' : 'Set tooltips' }}
       </button>

--- a/src/app/playground/playground.component.html
+++ b/src/app/playground/playground.component.html
@@ -76,6 +76,36 @@
   <hr />
 
   <div>
+    <h6>Dynamic NIL values</h6>
+
+    <div class="btn-container">
+      <button [tp]="nilTooltip" class="btn btn-outline-secondary">
+        I'm tooltip initialized to NIL. Click "Set tooltips" to see me.
+      </button>
+    </div>
+
+    <div class="btn-container">
+      <button [tp]="undefinedTooltip" class="btn btn-outline-secondary">
+        I'm tooltip initialized to undefined. Click "Set tooltips" to see me.
+      </button>
+    </div>
+
+    <div class="btn-container">
+      <button [tp]="emptyTooltip" class="btn btn-outline-secondary">
+        I'm tooltip initialized to empty string. Click "Set tooltips" to see me.
+      </button>
+    </div>
+
+    <div class="btn-container">
+      <button class="btn btn-outline-secondary" (click)="updateEmptyTooltips()">
+        {{ nilTooltip ? 'Unset tooltips' : 'Set tooltips' }}
+      </button>
+    </div>
+  </div>
+
+  <hr />
+
+  <div>
     <h6>Custom Template</h6>
 
     <div class="btn-container" id="custom-template">

--- a/src/app/playground/playground.component.ts
+++ b/src/app/playground/playground.component.ts
@@ -105,4 +105,13 @@ export class PlaygroundComponent {
   }
 
   visibility = false;
+
+  nilTooltip = null;
+  undefinedTooltip = undefined;
+  emptyTooltip = '';
+  updateEmptyTooltips(): void {
+    this.nilTooltip = this.nilTooltip ? null : "I'm updated NIL tooltip.";
+    this.undefinedTooltip = this.undefinedTooltip ? undefined : "I'm updated undefined tooltip.";
+    this.emptyTooltip = this.emptyTooltip ? '' : "I'm updated empty string tooltip.";
+  }
 }

--- a/src/app/playground/playground.component.ts
+++ b/src/app/playground/playground.component.ts
@@ -110,8 +110,8 @@ export class PlaygroundComponent {
   undefinedTooltip = undefined;
   emptyTooltip = '';
   updateEmptyTooltips(): void {
-    this.nilTooltip = this.nilTooltip ? null : "I'm updated NIL tooltip.";
-    this.undefinedTooltip = this.undefinedTooltip ? undefined : "I'm updated undefined tooltip.";
-    this.emptyTooltip = this.emptyTooltip ? '' : "I'm updated empty string tooltip.";
+    this.nilTooltip = this.nilTooltip ? null : "I'm updated NIL tooltip";
+    this.undefinedTooltip = this.undefinedTooltip ? undefined : "I'm updated undefined tooltip";
+    this.emptyTooltip = this.emptyTooltip ? '' : "I'm updated empty string tooltip";
   }
 }


### PR DESCRIPTION
fix: updating tp content from empty to value doesn't create the tp instance)

Fixes #138

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

#138 

## What is the new behavior?

The solution here is to create/destroy the instance depending on the content changes as well and not just on initialization.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
