### PR TITLE
refactor: always use native intersection observer

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "helipopper-playground",
   "version": "0.0.0",
   "engines": {
-    "node": "^18.10"
+    "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
   },
   "scripts": {
     "ng": "ng",

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -2,5 +2,5 @@ module.exports = {
   singleQuote: true,
   tabWidth: 2,
   useTabs: false,
-  printWidth: 120
+  printWidth: 90,
 };

--- a/projects/ngneat/helipopper/src/lib/intersection-observer.ts
+++ b/projects/ngneat/helipopper/src/lib/intersection-observer.ts
@@ -1,0 +1,9 @@
+// Let's retrieve the native `IntersectionObserver` implementation hidden by
+// `__zone_symbol__IntersectionObserver`. This would be the unpatched version of
+// the observer present in zone.js environments.
+// Otherwise, if the user is using zoneless change detection (and zone.js is not included),
+// we fall back to the native implementation. Accessing the native implementation
+// allows us to remove `runOutsideAngular` calls and reduce indentation,
+// making the code a bit more readable.
+export const IntersectionObserver: typeof globalThis.IntersectionObserver =
+  globalThis['__zone_symbol__IntersectionObserver'] || globalThis.IntersectionObserver;

--- a/projects/ngneat/helipopper/src/lib/utils.ts
+++ b/projects/ngneat/helipopper/src/lib/utils.ts
@@ -3,6 +3,8 @@ import { auditTime, map } from 'rxjs/operators';
 import { TippyElement } from './tippy.types';
 import { ElementRef } from '@angular/core';
 
+import { IntersectionObserver } from './intersection-observer';
+
 declare const ResizeObserver: any;
 
 let supportsIntersectionObserver = false;
@@ -48,7 +50,9 @@ export function isElementOverflow(host: HTMLElement): boolean {
   // Don't access the `offsetWidth` multiple times since it triggers layout updates.
   const hostOffsetWidth = host.offsetWidth;
 
-  return hostOffsetWidth > host.parentElement.offsetWidth || hostOffsetWidth < host.scrollWidth;
+  return (
+    hostOffsetWidth > host.parentElement.offsetWidth || hostOffsetWidth < host.scrollWidth
+  );
 }
 
 export function overflowChanges(host: TippyElement) {


### PR DESCRIPTION
In this commit, we retrieve the native `IntersectionObserver` implementation hidden by `__zone_symbol__IntersectionObserver`. This would be the unpatched version of the observer present in zone.js environments.
Otherwise, if the user is using zoneless change detection (and zone.js is not included), we fall back to the native implementation. Accessing the native implementation allows us to remove `runOutsideAngular` calls and reduce indentation, making the code a bit more readable.

I also reduced Prettier print width to 90, because 120 seems to be
large (the code overlaps the editor).