### PR TITLE
fix: enable strict mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "helipopper-playground",
       "version": "0.0.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@angular/animations": "^18.0.6",
         "@angular/common": "^18.0.6",
@@ -49,6 +50,7 @@
         "karma-jasmine-html-reporter": "^1.5.0",
         "lint-staged": "^9.2.0",
         "ng-packagr": "^18.0.0",
+        "patch-package": "8.0.0",
         "prettier": "2.8.8",
         "serve": "^11.3.2",
         "standard-version": "^8.0.2",
@@ -58,7 +60,7 @@
         "typescript": "~5.4.5"
       },
       "engines": {
-        "node": "^18.10"
+        "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -11450,6 +11452,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/find-yarn-workspace-root": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
+      "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+      "dev": true,
+      "dependencies": {
+        "micromatch": "^4.0.2"
+      }
+    },
     "node_modules/flat": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
@@ -13626,6 +13637,30 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
     },
+    "node_modules/json-stable-stringify": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.1.1.tgz",
+      "integrity": "sha512-SU/971Kt5qVQfJpyDveVhQ/vya+5hvrjClFOcr8c0Fq5aODJjMwutrOfCU+eCnVD5gpx1Q3fEqkyom77zH1iIg==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.5",
+        "isarray": "^2.0.5",
+        "jsonify": "^0.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/json-stable-stringify/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true
+    },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -13657,6 +13692,15 @@
       "dev": true,
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/jsonparse": {
@@ -13993,6 +14037,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/klaw-sync": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.11"
       }
     },
     "node_modules/launch-editor": {
@@ -16492,6 +16545,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/obuf": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
@@ -16839,6 +16901,207 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/patch-package": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.0.tgz",
+      "integrity": "sha512-da8BVIhzjtgScwDJ2TtKsfT5JFWz1hYoBl9rUQ1f38MC2HwnEIkK8VN3dKMKcP7P7bvvgzNDbfNHtx3MsQb5vA==",
+      "dev": true,
+      "dependencies": {
+        "@yarnpkg/lockfile": "^1.1.0",
+        "chalk": "^4.1.2",
+        "ci-info": "^3.7.0",
+        "cross-spawn": "^7.0.3",
+        "find-yarn-workspace-root": "^2.0.0",
+        "fs-extra": "^9.0.0",
+        "json-stable-stringify": "^1.0.2",
+        "klaw-sync": "^6.0.0",
+        "minimist": "^1.2.6",
+        "open": "^7.4.2",
+        "rimraf": "^2.6.3",
+        "semver": "^7.5.3",
+        "slash": "^2.0.0",
+        "tmp": "^0.0.33",
+        "yaml": "^2.2.2"
+      },
+      "bin": {
+        "patch-package": "index.js"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">5"
+      }
+    },
+    "node_modules/patch-package/node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/patch-package/node_modules/cross-spawn": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.5.tgz",
+      "integrity": "sha512-ZVJrKKYunU38/76t0RMOulHOnUcbU9GbpWKAOZ0mhjr7CX6FVrH+4FrAapSOekrgFQ3f/8gwMEuIft0aKq6Hug==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/patch-package/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/patch-package/node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/patch-package/node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/patch-package/node_modules/open": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "dev": true,
+      "dependencies": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/patch-package/node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/patch-package/node_modules/semver": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/patch-package/node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/patch-package/node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/patch-package/node_modules/slash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/patch-package/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/patch-package/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/patch-package/node_modules/yaml": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.0.tgz",
+      "integrity": "sha512-a6ae//JvKDEra2kdi1qzCyrJW/WZCgFi8ydDV+eXExl95t+5R+ijnqHJbz9tmMh8FUjx3iv2fCQ4dclAQlO2UQ==",
+      "dev": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/path-exists": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
   },
   "scripts": {
+    "postinstall": "patch-package",
     "ng": "ng",
     "start-test": "start-server-and-test",
     "deploy": "ng deploy --base-href=https://ngneat.github.io/helipopper/",
@@ -75,6 +76,7 @@
     "karma-jasmine-html-reporter": "^1.5.0",
     "lint-staged": "^9.2.0",
     "ng-packagr": "^18.0.0",
+    "patch-package": "8.0.0",
     "prettier": "2.8.8",
     "serve": "^11.3.2",
     "standard-version": "^8.0.2",

--- a/patches/tippy.js++@popperjs+core+2.10.2.patch
+++ b/patches/tippy.js++@popperjs+core+2.10.2.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/tippy.js/node_modules/@popperjs/core/lib/types.d.ts b/node_modules/tippy.js/node_modules/@popperjs/core/lib/types.d.ts
+index 11f9219..f971927 100644
+--- a/node_modules/tippy.js/node_modules/@popperjs/core/lib/types.d.ts
++++ b/node_modules/tippy.js/node_modules/@popperjs/core/lib/types.d.ts
+@@ -114,7 +114,7 @@ export declare type ModifierArguments<Options extends Obj> = {
+     options: Partial<Options>;
+     name: string;
+ };
+-export declare type Modifier<Name, Options> = {
++export declare type Modifier<Name, Options extends object> = {
+     name: Name;
+     enabled: boolean;
+     phase: ModifierPhases;

--- a/projects/ngneat/helipopper/src/lib/defaults.ts
+++ b/projects/ngneat/helipopper/src/lib/defaults.ts
@@ -1,22 +1,22 @@
-import { TippyConfig } from './tippy.types';
+import type { TippyProps } from './tippy.types';
 
-type Variation = TippyConfig['variations'][0];
+type Variation = Partial<TippyProps>;
 
 export const tooltipVariation: Variation = {
-  theme: null,
+  theme: undefined,
   arrow: false,
   animation: 'scale',
   trigger: 'mouseenter',
-  offset: [0, 5]
+  offset: [0, 5],
 };
 
 export const popperVariation: Variation = {
   theme: 'light',
   arrow: true,
   offset: [0, 10],
-  animation: null,
+  animation: undefined,
   trigger: 'click',
-  interactive: true
+  interactive: true,
 };
 
 export function withContextMenuVariation(baseVariation: Variation): Variation {
@@ -25,6 +25,6 @@ export function withContextMenuVariation(baseVariation: Variation): Variation {
     placement: 'right-start',
     trigger: 'manual',
     arrow: false,
-    offset: [0, 0]
+    offset: [0, 0],
   };
 }

--- a/projects/ngneat/helipopper/src/lib/intersection-observer.ts
+++ b/projects/ngneat/helipopper/src/lib/intersection-observer.ts
@@ -6,4 +6,5 @@
 // allows us to remove `runOutsideAngular` calls and reduce indentation,
 // making the code a bit more readable.
 export const IntersectionObserver: typeof globalThis.IntersectionObserver =
-  globalThis['__zone_symbol__IntersectionObserver'] || globalThis.IntersectionObserver;
+  (globalThis as any)['__zone_symbol__IntersectionObserver'] ||
+  globalThis.IntersectionObserver;

--- a/projects/ngneat/helipopper/src/lib/tippy.types.ts
+++ b/projects/ngneat/helipopper/src/lib/tippy.types.ts
@@ -1,7 +1,7 @@
 import type tippy from 'tippy.js';
 import type { Instance, Props } from 'tippy.js';
 import { ElementRef, InjectionToken, type InputSignal } from '@angular/core';
-import { ResolveViewRef, ViewOptions } from '@ngneat/overview';
+import type { ResolveViewRef, ViewOptions } from '@ngneat/overview';
 
 export interface CreateOptions extends Partial<TippyProps>, ViewOptions {
   variation: string;
@@ -9,27 +9,6 @@ export interface CreateOptions extends Partial<TippyProps>, ViewOptions {
   className: string | string[];
   data: any;
 }
-
-type InferInputSignalType<T> = T extends InputSignal<infer R> ? R : T;
-
-export type NgChanges<Component extends object, Props = ExcludeFunctions<Component>> = {
-  [Key in keyof Props]: {
-    previousValue: InferInputSignalType<Props[Key]>;
-    currentValue: InferInputSignalType<Props[Key]>;
-    firstChange: boolean;
-    isFirstChange(): boolean;
-  };
-};
-
-type MarkFunctionPropertyNames<Component> = {
-  [Key in keyof Component]: Component[Key] extends InputSignal<any>
-    ? Key
-    : Component[Key] extends Function
-    ? never
-    : Key;
-}[keyof Component];
-
-type ExcludeFunctions<T extends object> = Pick<T, MarkFunctionPropertyNames<T>>;
 
 export const TIPPY_REF = new InjectionToken<TippyInstance>('TIPPY_REF');
 
@@ -49,7 +28,7 @@ export interface ExtendedTippyProps extends TippyProps {
 export type TippyElement = ElementRef | Element;
 
 export interface ExtendedTippyInstance<T> extends TippyInstance {
-  view: ResolveViewRef<T>;
+  view: ResolveViewRef<T> | null;
   $viewOptions: ViewOptions;
   context?: ViewOptions['context'];
 }

--- a/projects/ngneat/helipopper/src/lib/utils.ts
+++ b/projects/ngneat/helipopper/src/lib/utils.ts
@@ -51,7 +51,8 @@ export function isElementOverflow(host: HTMLElement): boolean {
   const hostOffsetWidth = host.offsetWidth;
 
   return (
-    hostOffsetWidth > host.parentElement.offsetWidth || hostOffsetWidth < host.scrollWidth
+    hostOffsetWidth > host.parentElement!.offsetWidth ||
+    hostOffsetWidth < host.scrollWidth
   );
 }
 
@@ -83,7 +84,7 @@ function resizeObserverStrategy(target: HTMLElement): Observable<boolean> {
 }
 
 export function onlyTippyProps(allProps: any) {
-  const tippyProps = {};
+  const tippyProps: any = {};
 
   const ownProps = [
     'useTextContent',

--- a/projects/ngneat/helipopper/tsconfig.lib.json
+++ b/projects/ngneat/helipopper/tsconfig.lib.json
@@ -5,6 +5,7 @@
     "declarationMap": true,
     "declaration": true,
     "inlineSources": true,
+    "strict": true,
     "types": [],
     "lib": ["dom", "es2020"]
   },

--- a/src/app/playground/playground.component.ts
+++ b/src/app/playground/playground.component.ts
@@ -1,4 +1,10 @@
-import { ChangeDetectionStrategy, Component, ElementRef, ViewChild, computed } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  ViewChild,
+  computed,
+} from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { UntypedFormBuilder } from '@angular/forms';
 import { ExampleComponent } from '../example/example.component';
@@ -63,14 +69,16 @@ export class PlaygroundComponent {
   text3 = `Short`;
   comp = ExampleComponent;
 
-  @ViewChild('inputName', { static: true }) inputName: ElementRef;
-  @ViewChild('inputNameComp', { static: true }) inputNameComp: ElementRef;
+  @ViewChild('inputName', { static: true }) inputName!: ElementRef;
+  @ViewChild('inputNameComp', { static: true }) inputNameComp!: ElementRef;
 
   constructor(private fb: UntypedFormBuilder, private service: TippyService) {}
 
   toggleText(text: string, index: number) {
     const resolved =
-      text === `Only shown when text is overflowed ${index}` ? `Short` : `Only shown when text is overflowed`;
+      text === `Only shown when text is overflowed ${index}`
+        ? `Short`
+        : `Only shown when text is overflowed`;
 
     return `${resolved} ${index}`;
   }
@@ -87,7 +95,7 @@ export class PlaygroundComponent {
     console.log('show tooltip', $event);
   }
 
-  instance2: TippyInstance;
+  instance2!: TippyInstance;
 
   useService(host: HTMLButtonElement) {
     if (!this.instance2) {
@@ -97,7 +105,7 @@ export class PlaygroundComponent {
     }
   }
 
-  instance: TippyInstance;
+  instance!: TippyInstance;
 
   useServiceComponent(host2: HTMLButtonElement) {
     if (!this.instance) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "baseUrl": "./",
     "outDir": "./dist/out-tsc",
+    "strict": true,
     "sourceMap": true,
     "declaration": false,
     "downlevelIteration": true,


### PR DESCRIPTION
In this commit, we enable strict mode because it is required to generate correct type definition (`.d.ts`) files. These files differ depending on whether strict mode is enabled or disabled. Enabling strict mode allows `null|undefined` values to be provided by the parent component (e.g., `[tp]="null"`, which should be allowed), but the compiler removes `null|undefined` values from the binding.

We also had to patch the `@popperjs/core` types due to a mistake in their definitions. This patch was necessary for successful compilation.