### PR TITLE
refactor: do not export config entry and do some cleanups

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,8 @@ export const tooltipVariation = {
 ### Use `Component` as content
 
 ```ts
-import { injectTippyRef, TippyInstance } from '@ngneat/helipopper/config';
+import type { TippyInstance } from '@ngneat/helipopper/config';
+import { injectTippyRef } from '@ngneat/helipopper';
 
 @Component()
 class MyComponent {
@@ -315,7 +316,8 @@ tpVisible = new EventEmitter<boolean>();
 ### Create `tippy` Programmatically
 
 ```typescript
-import { TippyService, TippyInstance } from '@ngneat/helipopper';
+import type { TippyInstance } from '@ngneat/helipopper/config';
+import { TippyService } from '@ngneat/helipopper';
 
 class Component {
   @ViewChild('inputName') inputName: ElementRef;

--- a/projects/ngneat/helipopper/config/src/public-api.ts
+++ b/projects/ngneat/helipopper/config/src/public-api.ts
@@ -9,8 +9,6 @@ export {
   TippyConfig,
   TippyLoader,
   TIPPY_LOADER,
-  TIPPY_REF,
   TIPPY_CONFIG,
 } from './tippy.types';
 export { provideTippyLoader, provideTippyConfig } from './providers';
-export { injectTippyRef } from './inject-tippy';

--- a/projects/ngneat/helipopper/config/src/tippy.types.ts
+++ b/projects/ngneat/helipopper/config/src/tippy.types.ts
@@ -3,10 +3,6 @@ import type { Instance, Props } from 'tippy.js';
 import { ElementRef, InjectionToken } from '@angular/core';
 import type { ResolveViewRef, ViewOptions } from '@ngneat/overview';
 
-export const enum TippyErrorCode {
-  TippyNotProvided = 1,
-}
-
 export interface CreateOptions extends Partial<TippyProps>, ViewOptions {
   variation: string;
   preserveView: boolean;
@@ -41,10 +37,6 @@ export type TippyLoader = () => typeof tippy | Promise<{ default: typeof tippy }
 
 export const TIPPY_LOADER = new InjectionToken<TippyLoader>(
   typeof ngDevMode !== 'undefined' && ngDevMode ? 'TIPPY_LOADER' : ''
-);
-
-export const TIPPY_REF = /* @__PURE__ */ new InjectionToken<TippyInstance>(
-  typeof ngDevMode !== 'undefined' && ngDevMode ? 'TIPPY_REF' : ''
 );
 
 export const TIPPY_CONFIG = new InjectionToken<TippyConfig>(

--- a/projects/ngneat/helipopper/src/lib/inject-tippy.ts
+++ b/projects/ngneat/helipopper/src/lib/inject-tippy.ts
@@ -1,6 +1,11 @@
-import { inject } from '@angular/core';
+import { inject, InjectionToken } from '@angular/core';
+import type { TippyInstance } from '@ngneat/helipopper/config';
 
-import { TIPPY_REF, TippyErrorCode, type TippyInstance } from './tippy.types';
+import { TippyErrorCode } from './utils';
+
+export const TIPPY_REF = /* @__PURE__ */ new InjectionToken<TippyInstance>(
+  typeof ngDevMode !== 'undefined' && ngDevMode ? 'TIPPY_REF' : ''
+);
 
 export function injectTippyRef(): TippyInstance {
   const instance = inject(TIPPY_REF, { optional: true });

--- a/projects/ngneat/helipopper/src/lib/tippy.service.ts
+++ b/projects/ngneat/helipopper/src/lib/tippy.service.ts
@@ -12,12 +12,13 @@ import {
   CreateOptions,
   ExtendedTippyInstance,
   TIPPY_CONFIG,
-  TIPPY_REF,
   TippyConfig,
   TippyInstance,
 } from '@ngneat/helipopper/config';
-import { normalizeClassName, onlyTippyProps } from './utils';
+
+import { TIPPY_REF } from './inject-tippy';
 import { TippyFactory } from './tippy.factory';
+import { normalizeClassName, onlyTippyProps } from './utils';
 
 @Injectable({ providedIn: 'root' })
 export class TippyService {

--- a/projects/ngneat/helipopper/src/lib/utils.ts
+++ b/projects/ngneat/helipopper/src/lib/utils.ts
@@ -15,6 +15,10 @@ if (typeof window !== 'undefined') {
   supportsResizeObserver = 'ResizeObserver' in window;
 }
 
+export const enum TippyErrorCode {
+  TippyNotProvided = 1,
+}
+
 export function inView(
   host: TippyElement,
   options: IntersectionObserverInit = {
@@ -66,11 +70,7 @@ export function overflowChanges(host: TippyElement) {
 }
 
 export function dimensionsChanges(target: HTMLElement) {
-  return resizeObserverStrategy(target);
-}
-
-function resizeObserverStrategy(target: HTMLElement): Observable<boolean> {
-  return new Observable((subscriber) => {
+  return new Observable<boolean>((subscriber) => {
     if (!supportsResizeObserver) {
       subscriber.next();
       subscriber.complete();
@@ -122,25 +122,17 @@ export function onlyTippyProps(allProps: any) {
 }
 
 export function normalizeClassName(className: string | string[]): string[] {
-  const classes = isString(className) ? className.split(' ') : className;
+  const classes = typeof className === 'string' ? className.split(' ') : className;
 
   return classes.map((klass) => klass?.trim()).filter(Boolean);
 }
 
 export function coerceCssPixelValue<T>(value: T): string {
-  if (isNil(value)) {
+  if (value == null) {
     return '';
   }
 
   return typeof value === 'string' ? value : `${value}px`;
-}
-
-function isString(value: unknown): value is string {
-  return typeof value === 'string';
-}
-
-function isNil(value: any): value is undefined | null {
-  return value === undefined || value === null;
 }
 
 function coerceElement(element: TippyElement) {

--- a/projects/ngneat/helipopper/src/public-api.ts
+++ b/projects/ngneat/helipopper/src/public-api.ts
@@ -1,16 +1,4 @@
 export { TippyDirective } from './lib/tippy.directive';
 export { TippyService } from './lib/tippy.service';
 export { inView, overflowChanges } from './lib/utils';
-
-export {
-  ExtendedTippyInstance,
-  TippyInstance,
-  TIPPY_REF,
-  TippyConfig,
-  TIPPY_CONFIG,
-  tooltipVariation,
-  popperVariation,
-  withContextMenuVariation,
-  provideTippyConfig,
-  injectTippyRef,
-} from '@ngneat/helipopper/config';
+export { TIPPY_REF, injectTippyRef } from './lib/inject-tippy';

--- a/src/app/playground/playground.component.ts
+++ b/src/app/playground/playground.component.ts
@@ -8,7 +8,8 @@ import {
 import { toSignal } from '@angular/core/rxjs-interop';
 import { ReactiveFormsModule, UntypedFormBuilder } from '@angular/forms';
 import { ExampleComponent } from '../example/example.component';
-import { TippyDirective, TippyInstance, TippyService } from '@ngneat/helipopper';
+import type { TippyInstance } from '@ngneat/helipopper/config';
+import { TippyDirective, TippyService } from '@ngneat/helipopper';
 import type { Placement } from 'tippy.js';
 import { startWith } from 'rxjs';
 import { CommonModule } from '@angular/common';


### PR DESCRIPTION
In this commit, we avoid re-exporting items from the config entry point to prevent bundling these libraries together. Additionally, some functions have been removed because they are only used once. The `OnPush` strategy has also been improved to make it more automatic.