### PR TITLE
fix(release): change ngDevMode to isDevMode()

### DIFF
--- a/projects/ngneat/helipopper/config/src/tippy.types.ts
+++ b/projects/ngneat/helipopper/config/src/tippy.types.ts
@@ -1,6 +1,6 @@
 import type tippy from 'tippy.js';
 import type { Instance, Props } from 'tippy.js';
-import { ElementRef, InjectionToken } from '@angular/core';
+import { ElementRef, InjectionToken, isDevMode } from '@angular/core';
 import type { ResolveViewRef, ViewOptions } from '@ngneat/overview';
 
 export interface CreateOptions extends Partial<TippyProps>, ViewOptions {
@@ -36,17 +36,9 @@ export type TippyConfig = Partial<ExtendedTippyProps>;
 export type TippyLoader = () => typeof tippy | Promise<{ default: typeof tippy }>;
 
 export const TIPPY_LOADER = new InjectionToken<TippyLoader>(
-  typeof ngDevMode !== 'undefined' && ngDevMode ? 'TIPPY_LOADER' : ''
+  isDevMode() ? 'TIPPY_LOADER' : ''
 );
 
 export const TIPPY_CONFIG = new InjectionToken<TippyConfig>(
-  typeof ngDevMode !== 'undefined' && ngDevMode ? 'TIPPY_CONFIG' : ''
+  isDevMode() ? 'TIPPY_CONFIG' : ''
 );
-
-/** @internal */
-declare global {
-  // Indicates whether the application is operating in development mode.
-  // `ngDevMode` is a global flag set by Angular CLI.
-  // https://github.com/angular/angular-cli/blob/9b883fe28862c96720c7899b431174e9b47ad7e4/packages/angular/build/src/tools/esbuild/application-code-bundle.ts#L604
-  const ngDevMode: boolean;
-}

--- a/projects/ngneat/helipopper/src/lib/inject-tippy.ts
+++ b/projects/ngneat/helipopper/src/lib/inject-tippy.ts
@@ -1,17 +1,17 @@
-import { inject, InjectionToken } from '@angular/core';
+import { inject, InjectionToken, isDevMode } from '@angular/core';
 import type { TippyInstance } from '@ngneat/helipopper/config';
 
 import { TippyErrorCode } from './utils';
 
 export const TIPPY_REF = /* @__PURE__ */ new InjectionToken<TippyInstance>(
-  typeof ngDevMode !== 'undefined' && ngDevMode ? 'TIPPY_REF' : ''
+  isDevMode() ? 'TIPPY_REF' : ''
 );
 
 export function injectTippyRef(): TippyInstance {
   const instance = inject(TIPPY_REF, { optional: true });
 
   if (!instance) {
-    if (typeof ngDevMode !== 'undefined' && ngDevMode) {
+    if (isDevMode()) {
       throw new Error(
         'tp is not provided in the current context or on one of its ancestors'
       );


### PR DESCRIPTION
Angular best practice for checking dev mode, without conflicting global that doesn't pass Typescript's lib check.

Resolves #186, resolves #178

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [-] Tests for the changes have been added (for bug fixes / features)
- [-] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Currently `ngDevMode` is declared as a global const with a signature that doesn't match the same global const exported by Angular. This results in TypeScript errors when `tsconfig.json::compilerOptions.skipLibCheck` is set to false.

Issue Number: N/A

## What is the new behavior?

Instead of using `ngDevMode`, we use Angular's `isDevMode()` function to determine dev mode status, then take identical action as before.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information
