### PR TITLE
feat: add disableAll/enableAll to TippyService

### DIFF
--- a/cypress/e2e/helipopper-disable-all.cy.ts
+++ b/cypress/e2e/helipopper-disable-all.cy.ts
@@ -1,0 +1,74 @@
+Cypress.on('scrolled', (element) => {
+  element.get(0).scrollIntoView({
+    block: 'center',
+    inline: 'center',
+  });
+});
+
+describe('@ngneat/helipopper — disableAll / enableAll', () => {
+  const popperSelector = '.tippy-box .tippy-content';
+  const tooltipA = '[data-cy="disable-all-tooltip-a"]';
+  const tooltipB = '[data-cy="disable-all-tooltip-b"]';
+  const locallyDisabled = '[data-cy="disable-all-tooltip-local"]';
+  const toggleAll = '[data-cy="toggle-all-button"]';
+
+  beforeEach(() => {
+    cy.visit('/').wait(200);
+  });
+
+  it('should show tooltips when globally enabled (default)', () => {
+    cy.get(tooltipA).trigger('mouseenter');
+    cy.get(popperSelector).contains('Tooltip A').should('be.visible');
+
+    cy.get(tooltipA).trigger('mouseleave');
+
+    cy.get(tooltipB).trigger('mouseenter');
+    cy.get(popperSelector).contains('Tooltip B').should('be.visible');
+  });
+
+  it('should hide all tooltips after disableAll()', () => {
+    cy.get(toggleAll).should('contain', 'Disable All').click();
+
+    cy.get(tooltipA).trigger('mouseenter');
+    cy.get(popperSelector).should('not.exist');
+
+    cy.get(tooltipB).trigger('mouseenter');
+    cy.get(popperSelector).should('not.exist');
+  });
+
+  it('should restore all tooltips after enableAll()', () => {
+    cy.get(toggleAll).click(); // disable
+    cy.get(tooltipA).trigger('mouseenter');
+    cy.get(popperSelector).should('not.exist');
+
+    cy.get(toggleAll).click(); // re-enable
+    cy.get(tooltipA).trigger('mouseenter');
+    cy.get(popperSelector).contains('Tooltip A').should('be.visible');
+  });
+
+  it('should keep a locally-disabled tooltip hidden even after enableAll()', () => {
+    // Locally-disabled tooltip never shows while enabled globally.
+    cy.get(locallyDisabled).trigger('mouseenter');
+    cy.get(popperSelector).should('not.exist');
+
+    // Disable all, then re-enable — locally disabled should stay hidden.
+    cy.get(toggleAll).click();
+    cy.get(toggleAll).click();
+
+    cy.get(locallyDisabled).trigger('mouseenter');
+    cy.get(popperSelector).should('not.exist');
+  });
+
+  it('should survive multiple disable/enable cycles', () => {
+    for (let i = 0; i < 3; i++) {
+      cy.get(toggleAll).click(); // disable
+      cy.get(tooltipA).trigger('mouseenter');
+      cy.get(popperSelector).should('not.exist');
+
+      cy.get(toggleAll).click(); // enable
+      cy.get(tooltipA).trigger('mouseenter');
+      cy.get(popperSelector).contains('Tooltip A').should('be.visible');
+      cy.get(tooltipA).trigger('mouseleave');
+    }
+  });
+});

--- a/projects/ngneat/helipopper/src/lib/tippy.directive.ts
+++ b/projects/ngneat/helipopper/src/lib/tippy.directive.ts
@@ -51,6 +51,7 @@ import {
   TippyProps,
 } from '@ngneat/helipopper/config';
 import { TippyFactory } from './tippy.factory';
+import { TippyService } from './tippy.service';
 import { coerceBooleanAttribute } from './coercion';
 import { TIPPY_REF } from './inject-tippy';
 
@@ -234,6 +235,7 @@ export class TippyDirective implements OnChanges, AfterViewInit, OnInit {
   }
 
   private destroyRef = inject(DestroyRef);
+  private tippyService = inject(TippyService);
   private isServer =
     // Drop `isPlatformServer` once `ngServeMode` is available during compilation.
     (typeof ngServerMode !== 'undefined' && ngServerMode) ||
@@ -660,7 +662,7 @@ export class TippyDirective implements OnChanges, AfterViewInit, OnInit {
       untracked(() => this.contentChanged.next());
     });
 
-    effect(() => this.setStatus(this.isEnabled()));
+    effect(() => this.setStatus(this.tippyService.enabled() && this.isEnabled()));
 
     effect(() => {
       const isVisible = this.isVisible();

--- a/projects/ngneat/helipopper/src/lib/tippy.service.ts
+++ b/projects/ngneat/helipopper/src/lib/tippy.service.ts
@@ -1,4 +1,4 @@
-import { inject, Injectable, Injector } from '@angular/core';
+import { inject, Injectable, Injector, signal } from '@angular/core';
 import {
   isComponent,
   isTemplateRef,
@@ -25,6 +25,16 @@ export class TippyService {
   private readonly _globalConfig = inject(TIPPY_CONFIG, { optional: true });
   private readonly _viewService = inject(ViewService);
   private readonly _tippyFactory = inject(TippyFactory);
+
+  readonly enabled = signal(true);
+
+  enableAll(): void {
+    this.enabled.set(true);
+  }
+
+  disableAll(): void {
+    this.enabled.set(false);
+  }
 
   create<T extends Content>(
     host: HTMLElement,

--- a/src/app/playground/playground.component.html
+++ b/src/app/playground/playground.component.html
@@ -510,6 +510,39 @@
 
 <hr />
 
+<div id="disable-all" data-cy="disable-all-section">
+  <h6>Disable All / Enable All</h6>
+
+  <div class="btn-container">
+    <button tp="Tooltip A" class="btn btn-outline-dark" data-cy="disable-all-tooltip-a">
+      Tooltip A
+    </button>
+
+    <button tp="Tooltip B" class="btn btn-outline-dark" data-cy="disable-all-tooltip-b">
+      Tooltip B
+    </button>
+
+    <button
+      tp="Locally disabled"
+      [tpIsEnabled]="false"
+      class="btn btn-outline-dark"
+      data-cy="disable-all-tooltip-local"
+    >
+      Always disabled
+    </button>
+  </div>
+
+  <button
+    (click)="toggleAllEnabled()"
+    class="btn btn-outline-primary btn-sm mt-2"
+    data-cy="toggle-all-button"
+  >
+    {{ allEnabled ? 'Disable All' : 'Enable All' }}
+  </button>
+</div>
+
+<hr />
+
 <div>
   <h6>Use text content</h6>
   <span tp tpUseTextContent>{{ text }}</span>

--- a/src/app/playground/playground.component.ts
+++ b/src/app/playground/playground.component.ts
@@ -40,7 +40,7 @@ export class PlaygroundComponent {
 
   readonly tooltipSettings = toSignal(
     this.tooltipSettingsForm.valueChanges.pipe(startWith(this.tooltipSettingsForm.value)),
-    { requireSync: true }
+    { requireSync: true },
   );
 
   readonly tooltipPosition = computed(() => {
@@ -68,6 +68,7 @@ export class PlaygroundComponent {
   }));
 
   isEnabled = true;
+  allEnabled = true;
   text = `Only shown when text is overflowed 1`;
   text2 = `Short`;
   text3 = `Short`;
@@ -76,7 +77,10 @@ export class PlaygroundComponent {
   @ViewChild('inputName', { static: true }) inputName!: ElementRef;
   @ViewChild('inputNameComp', { static: true }) inputNameComp!: ElementRef;
 
-  constructor(private fb: UntypedFormBuilder, private service: TippyService) {}
+  constructor(
+    private fb: UntypedFormBuilder,
+    private service: TippyService,
+  ) {}
 
   toggleText(text: string, index: number) {
     const resolved =
@@ -93,6 +97,11 @@ export class PlaygroundComponent {
 
   toggleEnabled() {
     this.isEnabled = !this.isEnabled;
+  }
+
+  toggleAllEnabled() {
+    this.allEnabled = !this.allEnabled;
+    this.allEnabled ? this.service.enableAll() : this.service.disableAll();
   }
 
   handleStatus($event: boolean): void {


### PR DESCRIPTION
Adds a global `enabled` signal to `TippyService` with `disableAll()` and `enableAll()` methods. Each directive ANDs its local `tpIsEnabled` with the global signal, so a locally-disabled tooltip stays disabled after `enableAll()`.

Includes a playground section and Cypress e2e tests covering the default state, global disable/enable, the local-override invariant, and multiple cycles.

Closes #117