### PR TITLE
fix: detect vertical overflow for line-clamp truncation

### DIFF
--- a/projects/ngneat/helipopper/src/lib/utils.ts
+++ b/projects/ngneat/helipopper/src/lib/utils.ts
@@ -49,12 +49,14 @@ export function inView(
 }
 
 export function isElementOverflow(host: HTMLElement): boolean {
-  // Don't access the `offsetWidth` multiple times since it triggers layout updates.
+  // Don't access the `offsetWidth`/`offsetHeight` multiple times since it triggers layout updates.
   const hostOffsetWidth = host.offsetWidth;
+  const hostOffsetHeight = host.offsetHeight;
 
   return (
     hostOffsetWidth > host.parentElement!.offsetWidth ||
-    hostOffsetWidth < host.scrollWidth
+    hostOffsetWidth < host.scrollWidth ||
+    hostOffsetHeight < host.scrollHeight
   );
 }
 


### PR DESCRIPTION
isElementOverflow only checked horizontal overflow (scrollWidth vs offsetWidth), so -webkit-line-clamp truncation was never detected — the element clips vertically while its width stays unchanged.

Adding the offsetHeight < scrollHeight check covers multi-line clamp and any other CSS-driven vertical truncation.

Closes #195