### PR TITLE
feat: support inputBinding/outputBinding for dynamic components

### DIFF
--- a/cypress/e2e/helipopper.cy.ts
+++ b/cypress/e2e/helipopper.cy.ts
@@ -149,6 +149,16 @@ describe('@ngneat/helipopper', () => {
     });
   });
 
+  describe('Component bindings (tpBindings)', () => {
+    it('should pass inputBinding values to the component', () => {
+      cy.get('[data-cy="bindings-example-button"]')
+        .click({ force: true })
+        .get('app-bindings-example')
+        .contains('Greeting: Hello from inputBinding!')
+        .should('exist');
+    });
+  });
+
   describe('Dynamic content', () => {
     const dynamicButtonSelector = '[data-cy="dynamic-content"] .btn-container button';
     const setContentButton = '[data-cy="dynamic-content"] button:contains("Set Content")';

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@angular/platform-browser": "^21.2.8",
         "@angular/platform-browser-dynamic": "^21.2.8",
         "@angular/router": "^21.2.8",
-        "@ngneat/overview": "^7.0.0",
+        "@ngneat/overview": "^8.1.0",
         "rxjs": "~7.8.0",
         "tippy.js": "6.3.7",
         "tslib": "2.3.1",
@@ -57,7 +57,7 @@
         "typescript": "~5.9.2"
       },
       "engines": {
-        "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/@algolia/abtesting": {
@@ -6960,15 +6960,15 @@
       }
     },
     "node_modules/@ngneat/overview": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@ngneat/overview/-/overview-7.0.0.tgz",
-      "integrity": "sha512-nWSyoWHYGTyE6miNQ1AV2Or9yB+JcEwfQlCPhigq39HUd/Y40J28dAslIN2FCpAONBu2hm4XpYMb+Ya1DUgR2g==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@ngneat/overview/-/overview-8.1.0.tgz",
+      "integrity": "sha512-AX1Q8g7gH8S571TIYVGQ/qORF6MkbPR0RvlYu9OoRg/awOmJWKUO5s6+w9hKlAHt9CTPwXgoNwh3gRXAJAF+Mg==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.0"
       },
       "peerDependencies": {
-        "@angular/core": ">=20"
+        "@angular/core": ">=21"
       }
     },
     "node_modules/@ngneat/spectator": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@angular/platform-browser": "^21.2.8",
     "@angular/platform-browser-dynamic": "^21.2.8",
     "@angular/router": "^21.2.8",
-    "@ngneat/overview": "^7.0.0",
+    "@ngneat/overview": "^8.1.0",
     "rxjs": "~7.8.0",
     "tippy.js": "6.3.7",
     "tslib": "2.3.1",

--- a/projects/ngneat/helipopper/package.json
+++ b/projects/ngneat/helipopper/package.json
@@ -4,7 +4,7 @@
   "description": "A Powerful Tooltip and Popover for Angular Applications",
   "dependencies": {
     "tslib": "^2.3.0",
-    "@ngneat/overview": "^7.0.0",
+    "@ngneat/overview": "^8.1.0",
     "tippy.js": "6.3.7"
   },
   "peerDependencies": {

--- a/projects/ngneat/helipopper/src/lib/tippy.directive.ts
+++ b/projects/ngneat/helipopper/src/lib/tippy.directive.ts
@@ -183,6 +183,14 @@ export class TippyDirective implements OnChanges, AfterViewInit {
 
   readonly data = input<any>(undefined, { alias: 'tpData' });
 
+  /** Angular `inputBinding`/`outputBinding`/`twoWayBinding` descriptors forwarded to `createComponent`. */
+  readonly bindings = input<ViewOptions['bindings']>(undefined, { alias: 'tpBindings' });
+
+  /** Host directives (with optional bindings) forwarded to `createComponent`. */
+  readonly directives = input<ViewOptions['directives']>(undefined, {
+    alias: 'tpDirectives',
+  });
+
   readonly useHostWidth = input(false, {
     transform: coerceBooleanAttribute,
     alias: 'tpUseHostWidth',
@@ -526,6 +534,8 @@ export class TippyDirective implements OnChanges, AfterViewInit {
 
         this.viewOptions$ = {
           injector,
+          bindings: this.bindings(),
+          directives: this.directives(),
         };
       } else if (isTemplateRef(content)) {
         this.viewOptions$ = {

--- a/projects/ngneat/helipopper/src/lib/utils.ts
+++ b/projects/ngneat/helipopper/src/lib/utils.ts
@@ -112,6 +112,8 @@ export function onlyTippyProps(allProps: any) {
     'popperWidth',
     'zIndexGetter',
     'staticWidthHost',
+    'bindings',
+    'directives',
   ];
 
   const overriddenMethods = ['onShow', 'onHidden', 'onCreate'];

--- a/src/app/bindings-example/bindings-example.component.ts
+++ b/src/app/bindings-example/bindings-example.component.ts
@@ -1,0 +1,11 @@
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+
+@Component({
+  selector: 'app-bindings-example',
+  template: '<p>Greeting: {{ greeting() }}</p>',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  standalone: true,
+})
+export class BindingsExampleComponent {
+  readonly greeting = input<string>('');
+}

--- a/src/app/playground/playground.component.html
+++ b/src/app/playground/playground.component.html
@@ -528,3 +528,20 @@
 </div>
 
 <hr />
+
+<div id="component-bindings">
+  <h6>Component Bindings (inputBinding)</h6>
+  <div class="btn-container">
+    <button
+      class="btn btn-outline-primary"
+      [tp]="bindingsComp"
+      tpVariation="popper"
+      [tpBindings]="bindingsExampleBindings"
+      data-cy="bindings-example-button"
+    >
+      Open with bindings
+    </button>
+  </div>
+</div>
+
+<hr />

--- a/src/app/playground/playground.component.ts
+++ b/src/app/playground/playground.component.ts
@@ -4,10 +4,13 @@ import {
   ElementRef,
   ViewChild,
   computed,
+  inputBinding,
+  signal,
 } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { ReactiveFormsModule, UntypedFormBuilder } from '@angular/forms';
 import { ExampleComponent } from '../example/example.component';
+import { BindingsExampleComponent } from '../bindings-example/bindings-example.component';
 import type { TippyInstance } from '@ngneat/helipopper/config';
 import { TippyDirective, TippyService } from '@ngneat/helipopper';
 import type { Placement } from 'tippy.js';
@@ -72,6 +75,12 @@ export class PlaygroundComponent {
   text2 = `Short`;
   text3 = `Short`;
   comp = ExampleComponent;
+
+  bindingsComp = BindingsExampleComponent;
+  readonly bindingsGreeting = signal('Hello from inputBinding!');
+  readonly bindingsExampleBindings = [
+    inputBinding('greeting', () => this.bindingsGreeting()),
+  ];
 
   @ViewChild('inputName', { static: true }) inputName!: ElementRef;
   @ViewChild('inputNameComp', { static: true }) inputNameComp!: ElementRef;


### PR DESCRIPTION
Add tpBindings and tpDirectives inputs to TippyDirective and expose bindings/directives options in CreateOptions (already part of ViewOptions), allowing Angular's inputBinding(), outputBinding(), and twoWayBinding() descriptors to be forwarded to createComponent() when a component is used as tooltip content.

Also fix two Cypress test regressions introduced by the Angular 21 (zoneless) upgrade:
- onlyTextOverflow: add afterEveryRender hook to synchronously check overflow state after Angular's CD cycle, and an onShow guard that returns false when content is not overflowing. Restructure the "should show tooltip if text is overflowed" test to wait for the hide animation to complete before re-triggering, avoiding a race with tippy's transitionend-based DOM removal.
- hideOnEscape: add missing Escape keydown step that was masked by old Cypress mouse-event side-effects (pre-v12).

Closes #154